### PR TITLE
add data persistence to the slot and the mechs purchased for that slot.

### DIFF
--- a/IdleMechMobile/Assets/Scenes/MainGameScreen.unity
+++ b/IdleMechMobile/Assets/Scenes/MainGameScreen.unity
@@ -270,6 +270,7 @@ GameObject:
   - component: {fileID: 43860544}
   - component: {fileID: 43860543}
   - component: {fileID: 43860542}
+  - component: {fileID: 43860546}
   m_Layer: 5
   m_Name: PurchaseMechButton
   m_TagString: Untagged
@@ -312,17 +313,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   buttonTextConnection: {fileID: 113856127}
   costTextConnection: {fileID: 127430756}
-  mechName: 
+  mechName: Medium Mech
   purchaseCost:
     mantissa: 2
-    exponent: 4
+    exponent: 1
   totalAmount:
     mantissa: 0
     exponent: 0
   initialCost:
     mantissa: 2
-    exponent: 4
-  totalValuePerMech: 1
+    exponent: 1
+  totalValuePerMech: 2
   initialMultiplierCost: 1
 --- !u!114 &43860543
 MonoBehaviour:
@@ -406,6 +407,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 43860540}
   m_CullTransparentMesh: 1
+--- !u!114 &43860546
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 43860540}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 66ab5a3c91d831549b079a0952123df1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &68954358
 GameObject:
   m_ObjectHideFlags: 0
@@ -466,7 +479,7 @@ MonoBehaviour:
   m_text: 'Locked Mech Slot
 
 
-    Spend 1 Monz to Unlock'
+    Spend XXX Monz to Unlock'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -600,7 +613,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Spend 10e12 Monz
+  m_text: 'Spend XXX Monz
 
     To Upgrade'
   m_isRightToLeft: 0
@@ -1419,7 +1432,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 66ab5a3c91d831549b079a0952123df1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  upgradeManager: {fileID: 1430860360}
 --- !u!1 &127430754
 GameObject:
   m_ObjectHideFlags: 0
@@ -1477,7 +1489,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Spend 20e2 Monz
+  m_text: 'Spend XXX Monz
 
     To Purchase'
   m_isRightToLeft: 0
@@ -1960,11 +1972,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   mechSlots:
-  - {fileID: 1972626133}
-  - {fileID: 1650471941}
-  - {fileID: 1194650726}
-  monzManager: {fileID: 1887798682}
-  mechSelectionScreenManager: {fileID: 711815773}
+  - {fileID: 1972626141}
+  - {fileID: 1650471943}
+  - {fileID: 1194650728}
   mechSelected: 0
 --- !u!1 &286712547
 GameObject:
@@ -2336,10 +2346,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 5680125826446750639, guid: b2aacd9bd0e27b7439a6c7473ab02b0a, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1780752395}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b2aacd9bd0e27b7439a6c7473ab02b0a, type: 3}
 --- !u!4 &337991983 stripped
@@ -2517,75 +2524,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: -20, y: -20}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1001 &381156079
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 337991983}
-    m_Modifications:
-    - target: {fileID: 5062482826084967333, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_Name
-      value: SM_Bld_Floor_01
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 3.5921166
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.051666643
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.67663616
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.95057005
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.3105105
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
 --- !u!1 &403659765
 GameObject:
   m_ObjectHideFlags: 0
@@ -2854,7 +2792,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Spend 100 Monz
+  m_text: 'Spend XXX Monz
 
     To Upgrade'
   m_isRightToLeft: 0
@@ -3528,7 +3466,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Spend 10e3 Monz
+  m_text: 'Spend XXX Monz
 
     To Upgrade'
   m_isRightToLeft: 0
@@ -4701,11 +4639,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   mechSlotParent: {fileID: 267397077}
---- !u!4 &732590840 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-  m_PrefabInstance: {fileID: 1337438083}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &734369135
 GameObject:
   m_ObjectHideFlags: 0
@@ -5828,9 +5761,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d3ddde1d11c01c04b904917aee3cec2e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  textManager: {fileID: 750083788}
-  monzManager: {fileID: 1887798682}
-  cycleDuration: 6
+  cycleDuration: 1
   cycleTimer: 0
 --- !u!4 &880819413
 Transform:
@@ -5907,7 +5838,7 @@ MonoBehaviour:
   m_text: 'Locked Mech Slot
 
 
-    Spend 1 Monz to Unlock'
+    Spend XXX Monz to Unlock'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -7068,10 +6999,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 888354675364461467, guid: a9ee7d6a0d5a51242b2b432dcef60b53, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 732590840}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a9ee7d6a0d5a51242b2b432dcef60b53, type: 3}
 --- !u!4 &1000425044 stripped
@@ -7736,6 +7664,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   buttonText: {fileID: 897028229}
   mechSlotsParent: {fileID: 267397077}
+  mechSelected: 0
   lockedSlotButton: {fileID: 1194650730}
 --- !u!114 &1194650729
 MonoBehaviour:
@@ -7856,11 +7785,15 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1194650726}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1210b4d912adc5d41805bf9bf7c87b22, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  mechSlot: {fileID: 0}
+  isUnlocked: 0
+  isMechSelected: 0
+  mechName: 
 --- !u!1 &1254539800
 GameObject:
   m_ObjectHideFlags: 0
@@ -7919,6 +7852,7 @@ GameObject:
   - component: {fileID: 1296767383}
   - component: {fileID: 1296767382}
   - component: {fileID: 1296767381}
+  - component: {fileID: 1296767385}
   m_Layer: 5
   m_Name: PurchaseMechButton
   m_TagString: Untagged
@@ -7961,17 +7895,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   buttonTextConnection: {fileID: 317943456}
   costTextConnection: {fileID: 1949244555}
-  mechName: 
+  mechName: Heavy Mech
   purchaseCost:
-    mantissa: 1
-    exponent: 9
+    mantissa: 3
+    exponent: 1
   totalAmount:
     mantissa: 0
     exponent: 0
   initialCost:
-    mantissa: 1
-    exponent: 9
-  totalValuePerMech: 1
+    mantissa: 3
+    exponent: 1
+  totalValuePerMech: 3
   initialMultiplierCost: 1
 --- !u!114 &1296767382
 MonoBehaviour:
@@ -8055,6 +7989,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1296767379}
   m_CullTransparentMesh: 1
+--- !u!114 &1296767385
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1296767379}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 66ab5a3c91d831549b079a0952123df1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1302831433
 GameObject:
   m_ObjectHideFlags: 0
@@ -8248,7 +8194,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Spend 10 Monz
+  m_text: 'Spend XXX Monz
 
     To Purchase'
   m_isRightToLeft: 0
@@ -8327,75 +8273,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1316150165}
   m_CullTransparentMesh: 1
---- !u!1001 &1337438083
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1000425044}
-    m_Modifications:
-    - target: {fileID: 5062482826084967333, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_Name
-      value: SM_Bld_Floor_01
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 0.76923054
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.7692307
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.76923054
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 1.4755098
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.043846715
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -2.393503
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.99496853
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.100188285
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
 --- !u!1 &1374989439
 GameObject:
   m_ObjectHideFlags: 0
@@ -8516,14 +8393,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 642274fdd732853498f865f5f94e91b2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  monzManager: {fileID: 1887798682}
-  timeCycleManager: {fileID: 880819412}
-  totalMechsManager: {fileID: 1487677043}
---- !u!4 &1439275972 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-  m_PrefabInstance: {fileID: 2079993975}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1447481168
 GameObject:
   m_ObjectHideFlags: 0
@@ -8647,8 +8516,8 @@ GameObject:
   - component: {fileID: 1476154671}
   - component: {fileID: 1476154670}
   - component: {fileID: 1476154669}
-  - component: {fileID: 1476154672}
   - component: {fileID: 1476154673}
+  - component: {fileID: 1476154672}
   m_Layer: 5
   m_Name: UpgradeMechButton
   m_TagString: Untagged
@@ -8841,7 +8710,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 717af4687491d644b92d0a48c1e7ca50, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  monzManager: {fileID: 1887798682}
 --- !u!1 &1487687492
 GameObject:
   m_ObjectHideFlags: 0
@@ -9544,7 +9412,8 @@ GameObject:
   - component: {fileID: 1567024461}
   - component: {fileID: 1567024460}
   - component: {fileID: 1567024459}
-  - component: {fileID: 1567024458}
+  - component: {fileID: 1567024463}
+  - component: {fileID: 1567024462}
   m_Layer: 5
   m_Name: UpgradeMechButton
   m_TagString: Untagged
@@ -9573,32 +9442,6 @@ RectTransform:
   m_AnchoredPosition: {x: 150, y: -260}
   m_SizeDelta: {x: 180, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1567024458
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1567024456}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cc6ebc70f9de6e341906366197954706, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  buttonTextConnection: {fileID: 2008357443}
-  costTextConnection: {fileID: 93091526}
-  mechName: 
-  purchaseCost:
-    mantissa: 1
-    exponent: 13
-  totalAmount:
-    mantissa: 0
-    exponent: 0
-  initialCost:
-    mantissa: 1
-    exponent: 13
-  totalValuePerMech: 1
-  initialMultiplierCost: 1
 --- !u!114 &1567024459
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -9681,6 +9524,44 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1567024456}
   m_CullTransparentMesh: 1
+--- !u!114 &1567024462
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1567024456}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 494237586ec6d974b8708014669e3eee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  upgradeManager: {fileID: 1430860360}
+--- !u!114 &1567024463
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1567024456}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dfda8c5f0e93dae43bd062e17ea39332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  buttonTextConnection: {fileID: 1901830170}
+  costTextConnection: {fileID: 423599523}
+  mechName: Heavy Mech
+  upgradeCost:
+    mantissa: 1
+    exponent: 3
+  totalAmount:
+    mantissa: 1
+    exponent: 0
+  initialCost:
+    mantissa: 1
+    exponent: 3
+  multiplierAmount: 1
 --- !u!1001 &1610635357
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9982,6 +9863,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   buttonText: {fileID: 68954360}
   mechSlotsParent: {fileID: 267397077}
+  mechSelected: 0
   lockedSlotButton: {fileID: 1650471945}
 --- !u!114 &1650471944
 MonoBehaviour:
@@ -10102,11 +9984,15 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1650471941}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1210b4d912adc5d41805bf9bf7c87b22, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  mechSlot: {fileID: 0}
+  isUnlocked: 0
+  isMechSelected: 0
+  mechName: 
 --- !u!1 &1656016564
 GameObject:
   m_ObjectHideFlags: 0
@@ -10138,12 +10024,12 @@ Transform:
   m_Children:
   - {fileID: 880819413}
   - {fileID: 1887798683}
+  - {fileID: 1487677042}
   - {fileID: 750083789}
   - {fileID: 1430860359}
   - {fileID: 1254539801}
   - {fileID: 711815772}
   - {fileID: 267397076}
-  - {fileID: 1487677042}
   - {fileID: 2074078459}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -10519,10 +10405,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 2703116007232407169, guid: b67ef0a73678030468cc1fd4e45a90dc, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1439275972}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b67ef0a73678030468cc1fd4e45a90dc, type: 3}
 --- !u!4 &1702365973 stripped
@@ -10835,11 +10718,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1754046913}
   m_CullTransparentMesh: 1
---- !u!4 &1780752395 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-  m_PrefabInstance: {fileID: 381156079}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1794377768
 GameObject:
   m_ObjectHideFlags: 0
@@ -11084,7 +10962,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2cc1e5e28e6bcf94ab4b6a02c1a20273, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  textManager: {fileID: 750083788}
 --- !u!4 &1887798683
 Transform:
   m_ObjectHideFlags: 0
@@ -11293,7 +11170,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Spend 10e8 Monz
+  m_text: 'Spend XXX Monz
 
     To Purchase'
   m_isRightToLeft: 0
@@ -11790,6 +11667,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   buttonText: {fileID: 2036066835}
   mechSlotsParent: {fileID: 267397077}
+  mechSelected: 0
   lockedSlotButton: {fileID: 0}
 --- !u!114 &1972626142
 MonoBehaviour:
@@ -11798,11 +11676,15 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1972626133}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1210b4d912adc5d41805bf9bf7c87b22, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  mechSlot: {fileID: 0}
+  isUnlocked: 0
+  isMechSelected: 0
+  mechName: 
 --- !u!1 &1990726173
 GameObject:
   m_ObjectHideFlags: 0
@@ -12133,7 +12015,7 @@ MonoBehaviour:
   m_text: 'Locked Mech Slot
 
 
-    Spend 1 Monz to Unlock'
+    Spend XXX Monz to Unlock'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -12255,75 +12137,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   fileName: data.game
---- !u!1001 &2079993975
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1702365973}
-    m_Modifications:
-    - target: {fileID: 5062482826084967333, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_Name
-      value: SM_Bld_Floor_01
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 0.86956525
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.86956525
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.86956525
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 1.480073
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.014492863
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -2.8128827
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.9909831
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.13398694
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 5551352717961541919, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 745e2bc49b9287b4f94aa08b1fe9a2c1, type: 3}
 --- !u!1 &2134745902
 GameObject:
   m_ObjectHideFlags: 0
@@ -12472,7 +12285,8 @@ GameObject:
   - component: {fileID: 2136840377}
   - component: {fileID: 2136840376}
   - component: {fileID: 2136840375}
-  - component: {fileID: 2136840374}
+  - component: {fileID: 2136840379}
+  - component: {fileID: 2136840378}
   m_Layer: 5
   m_Name: UpgradeMechButton
   m_TagString: Untagged
@@ -12501,32 +12315,6 @@ RectTransform:
   m_AnchoredPosition: {x: 150, y: -260}
   m_SizeDelta: {x: 180, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &2136840374
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2136840372}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cc6ebc70f9de6e341906366197954706, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  buttonTextConnection: {fileID: 934706374}
-  costTextConnection: {fileID: 581205636}
-  mechName: 
-  purchaseCost:
-    mantissa: 1
-    exponent: 5
-  totalAmount:
-    mantissa: 0
-    exponent: 0
-  initialCost:
-    mantissa: 1
-    exponent: 5
-  totalValuePerMech: 1
-  initialMultiplierCost: 1
 --- !u!114 &2136840375
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -12609,6 +12397,44 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2136840372}
   m_CullTransparentMesh: 1
+--- !u!114 &2136840378
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2136840372}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 494237586ec6d974b8708014669e3eee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  upgradeManager: {fileID: 1430860360}
+--- !u!114 &2136840379
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2136840372}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dfda8c5f0e93dae43bd062e17ea39332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  buttonTextConnection: {fileID: 1901830170}
+  costTextConnection: {fileID: 423599523}
+  mechName: Medium Mech
+  upgradeCost:
+    mantissa: 1
+    exponent: 2
+  totalAmount:
+    mantissa: 1
+    exponent: 0
+  initialCost:
+    mantissa: 1
+    exponent: 2
+  multiplierAmount: 1
 --- !u!1 &2136969290
 GameObject:
   m_ObjectHideFlags: 0

--- a/IdleMechMobile/Assets/Scenes/MainGameScreen.unity
+++ b/IdleMechMobile/Assets/Scenes/MainGameScreen.unity
@@ -7664,7 +7664,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   buttonText: {fileID: 897028229}
   mechSlotsParent: {fileID: 267397077}
-  mechSelected: 0
   lockedSlotButton: {fileID: 1194650730}
 --- !u!114 &1194650729
 MonoBehaviour:
@@ -9863,7 +9862,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   buttonText: {fileID: 68954360}
   mechSlotsParent: {fileID: 267397077}
-  mechSelected: 0
   lockedSlotButton: {fileID: 1650471945}
 --- !u!114 &1650471944
 MonoBehaviour:
@@ -11667,7 +11665,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   buttonText: {fileID: 2036066835}
   mechSlotsParent: {fileID: 267397077}
-  mechSelected: 0
   lockedSlotButton: {fileID: 0}
 --- !u!114 &1972626142
 MonoBehaviour:

--- a/IdleMechMobile/Assets/Scripts/ButtonScripts/LockedMechSlotButton.cs
+++ b/IdleMechMobile/Assets/Scripts/ButtonScripts/LockedMechSlotButton.cs
@@ -5,6 +5,8 @@ using UnityEngine.UI;
 
 namespace ButtonScripts
 {
+    [RequireComponent(typeof(MechSlot))]
+    [RequireComponent(typeof(Button))]
     public class LockedMechSlotButton : ButtonParent
     {
         private MechSlot _mechSlot;
@@ -19,8 +21,7 @@ namespace ButtonScripts
 
         private void SendNewText()
         {
-            string priceToString = priceToUnlock.ToString();
-            string newText = $"Locked Mech Slot\n\nSpend {priceToString} Monz to Unlock";
+            string newText = $"Locked Mech Slot\n\nSpend {priceToUnlock.ToDouble()} Monz to Unlock";
             _mechSlot.CallUpdateMechSlotText(newText);
         }
         public BigDouble GetPriceToUnlock()

--- a/IdleMechMobile/Assets/Scripts/ButtonScripts/MechOverlayOpenButton.cs
+++ b/IdleMechMobile/Assets/Scripts/ButtonScripts/MechOverlayOpenButton.cs
@@ -23,12 +23,14 @@ namespace ButtonScripts
             
             if (!_mechSlot.CheckMechSelected())
             {
+                Debug.Log($"MOOB: In slot {_mechSlot.gameObject.name} but no mech selected", gameObject);
                 ButtonChild.onClick.AddListener(MechOverlaySwapScreen);
                 _mechSelected = false;
             }
 
             if (_mechSlot.CheckMechSelected() && _mechSlot == _mechSlot.RequestActiveMechSlot())
             {
+                Debug.Log($"MOOB: in slot {_mechSlot.gameObject.name}, mechSelected and RequestActiveMechSlot() true", gameObject);
                 _mechSlot.SetupOverlayButton();
                 _mechSelected = true;
             }

--- a/IdleMechMobile/Assets/Scripts/ButtonScripts/MechOverlayOpenButton.cs
+++ b/IdleMechMobile/Assets/Scripts/ButtonScripts/MechOverlayOpenButton.cs
@@ -5,6 +5,8 @@ using UnityEngine.UI;
 
 namespace ButtonScripts
 {
+    [RequireComponent(typeof(MechSlot))]
+    [RequireComponent(typeof(Button))]
     public class MechOverlayOpenButton : ButtonParent
     {
         private MechSlot _mechSlot;

--- a/IdleMechMobile/Assets/Scripts/ButtonScripts/SelectMechTypeButton.cs
+++ b/IdleMechMobile/Assets/Scripts/ButtonScripts/SelectMechTypeButton.cs
@@ -5,27 +5,36 @@ using UnityEngine.UI;
 
 namespace ButtonScripts
 {
+    [RequireComponent(typeof(Button))]
     public class SelectMechTypeButton : ButtonParent
     {
         //Now we must make logic in here to lock down the extra mech types unless they have been
         //researched through the upgrade tree
         private MechSlot _mechSlot;
         [SerializeField] private MechSelectionScreenManager mechSelectionScreenManager;
+        
+        // public get private set private string mechName
         [SerializeField] private string mechName;
+        public string MechName
+        {
+            get => mechName;
+            private set => mechName = value;
+        }
+        
         [SerializeField] private GameObject overlayScreen;
         [SerializeField] private GameObject mechPurchaseScreen;
         private void OnEnable()
         {
             if (!ButtonChild) ButtonChild = GetComponent<Button>();
-            
-
             ButtonChild.onClick.AddListener(CallSelectMech);
         }
 
-        private void CallSelectMech()
+        public void CallSelectMech()
         {
-            //mechSelectionScreenManager.MechSelected(ButtonChild);
-            ButtonChild.interactable = false;
+            if (! MonzManager.Instance.IsLoading )
+            {
+                ButtonChild.interactable = false;
+            }
             mechSelectionScreenManager.AffectMechSlot(mechName, overlayScreen);
             screenManagerChild.SwapScreenTo(mechPurchaseScreen);
         }

--- a/IdleMechMobile/Assets/Scripts/DataPersistence/DataPersistenceManager.cs
+++ b/IdleMechMobile/Assets/Scripts/DataPersistence/DataPersistenceManager.cs
@@ -20,7 +20,7 @@ namespace DataPersistence
 
         private void Start()
         {
-            Debug.Log($"In DataPersistenceManager Start");
+            Debug.Log($"DPM: In DataPersistenceManager Start");
             _dataHandler = new FileDataHandler(Application.persistentDataPath, fileName);
             _dataPersistenceObjects = FindAllDataPersistenceObjects();
             LoadGame();
@@ -40,7 +40,7 @@ namespace DataPersistence
             
             if (_gameData == null)
             {
-                Debug.Log("No saved data found. Initializing data to defaults");
+                Debug.Log("DPM: No saved data found. Initializing data to defaults");
                 NewGame();
             }
             // using this delegate to wait until we know the scene is done loading
@@ -58,7 +58,7 @@ namespace DataPersistence
             // };
             foreach (var dataPersistenceObj in _dataPersistenceObjects)
             {
-                Debug.Log($"loading data for {dataPersistenceObj.GetType().Name} ", gameObject);
+                Debug.Log($"DPM: loading data for {dataPersistenceObj.GetType().Name} ", gameObject);
                 dataPersistenceObj.LoadData(_gameData);
             }
             

--- a/IdleMechMobile/Assets/Scripts/DataPersistence/GameData.cs
+++ b/IdleMechMobile/Assets/Scripts/DataPersistence/GameData.cs
@@ -11,11 +11,13 @@ namespace DataPersistence
     {
         public BigDouble totalMonzSaved;
         public BigDouble monzPerCycleSaved;
-        public List<MechSlotSaveObject> mechSlotsSaved;
+        // public List<MechSlotSaveObject> mechSlotsSaved;
         public List<MechCollection> allMechsSaved;
         public GameData()
         {
+            Debug.Log($"Initializing Game Data");
             totalMonzSaved = 0;
+            monzPerCycleSaved = 0;
         }
     }
 }

--- a/IdleMechMobile/Assets/Scripts/DataPersistence/GameData.cs
+++ b/IdleMechMobile/Assets/Scripts/DataPersistence/GameData.cs
@@ -15,7 +15,7 @@ namespace DataPersistence
         public List<MechCollection> allMechsSaved;
         public GameData()
         {
-            Debug.Log($"Initializing Game Data");
+            Debug.Log($"GD: Initializing Game Data");
             totalMonzSaved = 0;
             monzPerCycleSaved = 0;
         }

--- a/IdleMechMobile/Assets/Scripts/EditorExtensions/MaterialApplication.cs
+++ b/IdleMechMobile/Assets/Scripts/EditorExtensions/MaterialApplication.cs
@@ -1,27 +1,27 @@
-using UnityEngine;
-using UnityEditor;
-namespace EditorExtensions
-{
-    [CustomEditor(typeof(MechMeshEditorControl))]
-    public class MaterialApplication : Editor
-    {
-        
-        public override void OnInspectorGUI()
-        {
-            DrawDefaultInspector();
-            
-            var mechMesh = (MechMeshEditorControl)target;
-
-            if (GUILayout.Button("Swap Materials"))
-            {
-                mechMesh.ChangeMat();
-                Debug.Log("Swapping mats");
-            }
-
-            if (GUILayout.Button("Clear children"))
-            {
-                mechMesh.ClearChildren();
-            }
-        }
-    }
-}
+// using UnityEngine;
+// using UnityEditor;
+// namespace EditorExtensions
+// {
+//     [CustomEditor(typeof(MechMeshEditorControl))]
+//     public class MaterialApplication : Editor
+//     {
+//         
+//         public override void OnInspectorGUI()
+//         {
+//             DrawDefaultInspector();
+//             
+//             var mechMesh = (MechMeshEditorControl)target;
+//
+//             if (GUILayout.Button("Swap Materials"))
+//             {
+//                 mechMesh.ChangeMat();
+//                 Debug.Log("Swapping mats");
+//             }
+//
+//             if (GUILayout.Button("Clear children"))
+//             {
+//                 mechMesh.ClearChildren();
+//             }
+//         }
+//     }
+// }

--- a/IdleMechMobile/Assets/Scripts/GameLoopScripts/PurchaseMech.cs
+++ b/IdleMechMobile/Assets/Scripts/GameLoopScripts/PurchaseMech.cs
@@ -7,11 +7,13 @@ using Managers;
 namespace GameLoopScripts
 {
     //Not making ButtonParent the parent of these scripts as we need nothing in that script for what happens here
+    [RequireComponent(typeof(Button))]
+    [RequireComponent(typeof(PurchaseInfo))]
     public class PurchaseMech : MonoBehaviour
     {
         private Button _button;
         private PurchaseInfo _purchaseInfo;
-        [SerializeField] private UpgradeManager upgradeManager;
+        // [SerializeField] private UpgradeManager upgradeManager;
         private void OnEnable()
         {
             if (!_button) _button = GetComponent<Button>();
@@ -21,9 +23,13 @@ namespace GameLoopScripts
 
         private void RequestMechPurchase()
         {
-            if (upgradeManager.CallPurchaseMech(_purchaseInfo))
+            if (UpgradeManager.Instance.CallPurchaseMech(_purchaseInfo))
             {
                 //Do some fancy sound or visual here to show the player bought the mech
+            }
+            else
+            {
+                Debug.Log($"Didn't have enough monz according to {_purchaseInfo.purchaseCost}");
             }
         }
         

--- a/IdleMechMobile/Assets/Scripts/Managers/MonzManager.cs
+++ b/IdleMechMobile/Assets/Scripts/Managers/MonzManager.cs
@@ -5,37 +5,37 @@ using UnityEngine;
 
 namespace Managers
 {
-    public class MonzManager : MonoBehaviour, IDataPersistence
+    public class MonzManager : Singleton<MonzManager>, IDataPersistence
     {
-        [SerializeField] private TextManager textManager;
-        //TODO: This value needs to be saved in the save system
         private BigDouble _monzBigDoubleHolder;
         private BigDouble _monzPerCycle;
-        
+        private bool _isLoading;
+        public bool IsLoading => _isLoading;
+
         private void Start()
         {
-            if (_monzPerCycle == 0)
+            Debug.Log($"{nameof(MonzManager)} started");
+            if (_monzPerCycle < 1)
             {
-                _monzPerCycle++;
+                _monzPerCycle = 1;
             }
-            //This if check will be modified to respond when we load in the playerprefs
-            //If the playerpref is empty, we set the value to default
-            //if (PlayerPrefs.GetInt(UpgradeCost))
-            //{
             UpdateStartMoneyText();
-            //    _currentUpgradeMoneyCost = PlayerPrefs.GetInt(UpgradeCost);
-            //}
-            
         }
 
         private void UpdateStartMoneyText()
         {
-            textManager.UpdateMonzText(_monzBigDoubleHolder);
-            textManager.UpdateCycleValueText(_monzPerCycle);
+            Debug.Log($"updating money text to {_monzBigDoubleHolder} and {_monzPerCycle}");
+            TextManager.Instance.UpdateMonzText(_monzBigDoubleHolder);
+            TextManager.Instance.UpdateCycleValueText(_monzPerCycle);
         }
         public void IncreaseMoney()
         {
             ModifyingMonzTotal(_monzPerCycle, true);
+        }
+
+        public void SetLoadBool(bool isLoading)
+        {
+            _isLoading = isLoading;
         }
 
         public void IncreaseCycleValue(BigDouble cycleValueUp)
@@ -52,18 +52,19 @@ namespace Managers
             {
                 _monzPerCycle -= valueToModifyBy;
             }
-            textManager.UpdateCycleValueText(_monzPerCycle);
+            TextManager.Instance.UpdateCycleValueText(_monzPerCycle);
         }
         
         public void UpdateCycleValue(BigDouble newCycleValue)
         {
             _monzPerCycle = newCycleValue;
-            textManager.UpdateCycleValueText(_monzPerCycle);
+            TextManager.Instance.UpdateCycleValueText(_monzPerCycle);
         }
 
         
         public bool TrySpend(BigDouble priceIncoming)
         {
+            if (_isLoading) return true; // during load state, allow logic to run without impacting monz balance
             if (priceIncoming > _monzBigDoubleHolder) return false;
             ModifyingMonzTotal(priceIncoming, false);
             return true;
@@ -79,29 +80,30 @@ namespace Managers
             {
                 _monzBigDoubleHolder -= priceToModifyBy;
             }
-            textManager.UpdateMonzText(_monzBigDoubleHolder);
+            TextManager.Instance.UpdateMonzText(_monzBigDoubleHolder);
         }
         
         public bool UpgradeValue(PurchaseInfo info)
         {
-            if (!TrySpend(info.purchaseCost))
+            if (! _isLoading && !TrySpend(info.purchaseCost) ) // if not in load state, and you can't afford, false
             {
                 return false;
             } 
             info.totalAmount++;
             
             info.purchaseCost = info.initialCost * info.totalAmount * 1.2;
-        
-
-            textManager.UpdateMonzText(_monzBigDoubleHolder);
-            textManager.UpdateUpgradeCostText(info.purchaseCost, info.costTextConnection);
+            
+            TextManager.Instance.UpdateMonzText(_monzBigDoubleHolder);
+            TextManager.Instance.UpdateUpgradeCostText(info.purchaseCost, info.costTextConnection);
             return true;
         }
         public bool UpgradeValue(UpgradeInfo info)
         {
-            Debug.Log(info.upgradeCost);
+            // Debug.Log(info.upgradeCost);
+            
             if (!TrySpend(info.upgradeCost))
             {
+                Debug.Log($"Can't spend {info.upgradeCost}", gameObject);
                 return false;
             } 
             //This is the current way we calculate the cost of each upgrade, based off its initial cost times the total
@@ -113,21 +115,24 @@ namespace Managers
             //amount is bought, then going to 1.2 or whatever. This scaling only works once
             //there are upgrades that increase the value each mech is generating.
             info.upgradeCost = info.initialCost * info.totalAmount * .8;
-        
-
-            textManager.UpdateMonzText(_monzBigDoubleHolder);
-            textManager.UpdateUpgradeCostText(info.upgradeCost, info.costTextConnection);
+            
+            TextManager.Instance.UpdateMonzText(_monzBigDoubleHolder);
+            TextManager.Instance.UpdateUpgradeCostText(info.upgradeCost, info.costTextConnection);
             return true;
         }
 
         public void LoadData(GameData data)
         {
-            _monzBigDoubleHolder = data.totalMonzSaved;
-            _monzPerCycle = data.monzPerCycleSaved;
+            SetLoadBool(true); // tell the monz manager that we are in load process, to not check or deduct money
+            Debug.Log($"in LoadData of MonzManager {data.totalMonzSaved} {data.monzPerCycleSaved}");
+            ModifyingMonzTotal(data.totalMonzSaved, increase: true);  // use real methods to explicitly call logic in them
+            ModifyCycleMonzValue(data.monzPerCycleSaved, increase: true);
+            SetLoadBool(false); // tell the monz manager that we are in load process, to not check or deduct money
         }
 
         public void SaveData(ref GameData data)
         {
+            Debug.Log($"In SaveData of MonzManager: {_monzBigDoubleHolder} {_monzPerCycle}");
             data.totalMonzSaved = _monzBigDoubleHolder;
             data.monzPerCycleSaved = _monzPerCycle;
         }

--- a/IdleMechMobile/Assets/Scripts/Managers/MonzManager.cs
+++ b/IdleMechMobile/Assets/Scripts/Managers/MonzManager.cs
@@ -1,5 +1,6 @@
 using BreakInfinity;
 using DataPersistence;
+using MechMenuScripts;
 using Serialized;
 using UnityEngine;
 
@@ -14,7 +15,7 @@ namespace Managers
 
         private void Start()
         {
-            Debug.Log($"{nameof(MonzManager)} started");
+            Debug.Log($"MM: {nameof(MonzManager)} started");
             if (_monzPerCycle < 1)
             {
                 _monzPerCycle = 1;
@@ -24,7 +25,7 @@ namespace Managers
 
         private void UpdateStartMoneyText()
         {
-            Debug.Log($"updating money text to {_monzBigDoubleHolder} and {_monzPerCycle}");
+            Debug.Log($"MM: updating money text to {_monzBigDoubleHolder} and {_monzPerCycle}");
             TextManager.Instance.UpdateMonzText(_monzBigDoubleHolder);
             TextManager.Instance.UpdateCycleValueText(_monzPerCycle);
         }
@@ -103,7 +104,7 @@ namespace Managers
             
             if (!TrySpend(info.upgradeCost))
             {
-                Debug.Log($"Can't spend {info.upgradeCost}", gameObject);
+                Debug.Log($"MM: Can't spend {info.upgradeCost}", gameObject);
                 return false;
             } 
             //This is the current way we calculate the cost of each upgrade, based off its initial cost times the total
@@ -124,7 +125,7 @@ namespace Managers
         public void LoadData(GameData data)
         {
             SetLoadBool(true); // tell the monz manager that we are in load process, to not check or deduct money
-            Debug.Log($"in LoadData of MonzManager {data.totalMonzSaved} {data.monzPerCycleSaved}");
+            Debug.Log($"MM: in LoadData {data.totalMonzSaved} {data.monzPerCycleSaved}");
             ModifyingMonzTotal(data.totalMonzSaved, increase: true);  // use real methods to explicitly call logic in them
             ModifyCycleMonzValue(data.monzPerCycleSaved, increase: true);
             SetLoadBool(false); // tell the monz manager that we are in load process, to not check or deduct money
@@ -132,7 +133,7 @@ namespace Managers
 
         public void SaveData(ref GameData data)
         {
-            Debug.Log($"In SaveData of MonzManager: {_monzBigDoubleHolder} {_monzPerCycle}");
+            Debug.Log($"MM: In SaveData {_monzBigDoubleHolder} {_monzPerCycle}");
             data.totalMonzSaved = _monzBigDoubleHolder;
             data.monzPerCycleSaved = _monzPerCycle;
         }

--- a/IdleMechMobile/Assets/Scripts/Managers/ScreenManager.cs
+++ b/IdleMechMobile/Assets/Scripts/Managers/ScreenManager.cs
@@ -1,3 +1,4 @@
+using MechMenuScripts;
 using UnityEngine;
 
 namespace Managers
@@ -6,6 +7,7 @@ namespace Managers
     {
         [SerializeField] private GameObject currentlyActiveScreen;
         private GameObject _activeOverlayScreen;
+        [SerializeField] private MechSlotsParent MechSlotsParent;
         private void Start()
         {
             if (currentlyActiveScreen) return;
@@ -24,6 +26,7 @@ namespace Managers
 
         public void OpenOverlayScreen(GameObject overlayScreen)
         {
+            Debug.Log($"SM: Opening overlay screen: {overlayScreen.name}", gameObject);
             _activeOverlayScreen = overlayScreen;
             _activeOverlayScreen.SetActive(true);
         }
@@ -36,8 +39,12 @@ namespace Managers
         
         public void CloseOverlayScreen()
         {
+            Debug.Log($"SM: Closing all overlay screens", gameObject);
             _activeOverlayScreen.SetActive(false);
             _activeOverlayScreen = null;
+            
+            // todo: tell MechSlotsParent to clear his state tracking as well
+            MechSlotsParent.ClearSelectedMechSlot();
         }
     }
 }

--- a/IdleMechMobile/Assets/Scripts/Managers/Singleton.cs
+++ b/IdleMechMobile/Assets/Scripts/Managers/Singleton.cs
@@ -10,7 +10,7 @@ public class Singleton<T> : MonoBehaviour where T : MonoBehaviour
         {
             if (_instance == null)
             {
-                Debug.Log($"Someone tried to get and _instance is null, searching or creating  {typeof(T)}");
+                Debug.Log($"S: Someone tried to get and _instance is null, searching or creating  {typeof(T)}");
                 _instance = FindOrCreateInstance();
             }
             return _instance;
@@ -22,7 +22,7 @@ public class Singleton<T> : MonoBehaviour where T : MonoBehaviour
         var Instance = GameObject.FindObjectOfType<T>();
         if (Instance != null)
         {
-            Debug.Log($"Found and returning instance of {typeof(T)} on gameObject {Instance.gameObject.name}");
+            Debug.Log($"S: Found and returning instance of {typeof(T)} on gameObject {Instance.gameObject.name}");
             return Instance;
         }
         

--- a/IdleMechMobile/Assets/Scripts/Managers/Singleton.cs
+++ b/IdleMechMobile/Assets/Scripts/Managers/Singleton.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+
+public class Singleton<T> : MonoBehaviour where T : MonoBehaviour
+{
+    private static T _instance;
+
+    public static T Instance
+    {
+        get
+        {
+            if (_instance == null)
+            {
+                Debug.Log($"Someone tried to get and _instance is null, searching or creating  {typeof(T)}");
+                _instance = FindOrCreateInstance();
+            }
+            return _instance;
+        }
+    }
+
+    private static T FindOrCreateInstance()
+    {
+        var Instance = GameObject.FindObjectOfType<T>();
+        if (Instance != null)
+        {
+            Debug.Log($"Found and returning instance of {typeof(T)} on gameObject {Instance.gameObject.name}");
+            return Instance;
+        }
+        
+        var name = typeof(T).Name + " Singleton";
+        var containerGameObject = new GameObject(name);
+        var singletonComponent = containerGameObject.AddComponent<T>();
+        return singletonComponent;
+    }
+}

--- a/IdleMechMobile/Assets/Scripts/Managers/TextManager.cs
+++ b/IdleMechMobile/Assets/Scripts/Managers/TextManager.cs
@@ -5,15 +5,15 @@ using UnityEngine.UI;
 
 namespace Managers
 {
-    public class TextManager : MonoBehaviour
+    public class TextManager : Singleton<TextManager>
     {
         [SerializeField] private TextMeshProUGUI moneyCounterText;
-
         [SerializeField] private TextMeshProUGUI cycleValueText;
         [SerializeField] private TextMeshProUGUI cycleTimerText;
         [SerializeField] private GameObject cycleVisual;
         private Image _cycleFillIn;
 
+        
         private void Start()
         {
             _cycleFillIn = cycleVisual.GetComponent<Image>();
@@ -21,17 +21,17 @@ namespace Managers
 
         public void UpdateUpgradeCostText(BigDouble upgradedCost, TMP_Text textToUpdate)
         {
-            textToUpdate.text = "Spend " + upgradedCost.ToString("G6") + " Monz\nTo Upgrade";
+            textToUpdate.text = $"Spend {upgradedCost.ToDouble()} Monz\nTo Upgrade";
         }
     
         public void UpdateMonzText(BigDouble value)
         {
-            moneyCounterText.text = "Monz: " + value.ToString("G6");
+            moneyCounterText.text = $"Monz: {value.ToDouble()}";
         }
 
         public void UpdateCycleValueText(BigDouble value)
         {
-            cycleValueText.text = value.ToString("G6") + " Monz Per Cycle";
+            cycleValueText.text = $"{value.ToDouble()} Monz Per Cycle";
         }
 
         public void UpdateCycleTimer(float value, float maxValue)

--- a/IdleMechMobile/Assets/Scripts/Managers/TimeCycleManager.cs
+++ b/IdleMechMobile/Assets/Scripts/Managers/TimeCycleManager.cs
@@ -3,12 +3,11 @@ using UnityEngine.Serialization;
 
 namespace Managers
 {
-    public class TimeCycleManager : MonoBehaviour
+    public class TimeCycleManager : Singleton<TimeCycleManager>
     {
-        [SerializeField] private TextManager textManager;
-        [FormerlySerializedAs("moneyManager")] [SerializeField] private MonzManager monzManager;
         [SerializeField] float cycleDuration;
         [SerializeField] float cycleTimer;
+     
         // Start is called before the first frame update
         void Start()
         {
@@ -21,10 +20,10 @@ namespace Managers
         void Update()
         {
             cycleTimer -= Time.deltaTime;
-            textManager.UpdateCycleTimer(cycleTimer, cycleDuration);
+            TextManager.Instance.UpdateCycleTimer(cycleTimer, cycleDuration);
             if (!(cycleTimer < 0.0f)) return;
             cycleTimer = cycleDuration;
-            monzManager.IncreaseMoney();
+            MonzManager.Instance.IncreaseMoney();
         }
     
     

--- a/IdleMechMobile/Assets/Scripts/Managers/TotalMechsManager.cs
+++ b/IdleMechMobile/Assets/Scripts/Managers/TotalMechsManager.cs
@@ -2,22 +2,22 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using BreakInfinity;
+using ButtonScripts;
 using DataPersistence;
+using MechMenuScripts;
 using Serialized;
 using UnityEngine;
-using UnityEngine.Serialization;
 
 namespace Managers
 {
-    public class TotalMechsManager : MonoBehaviour, IDataPersistence
+    public class TotalMechsManager : Singleton<TotalMechsManager>, IDataPersistence
     {
-        //TODO: This list needs to be saved in the save system
         private List<MechCollection> _allMechs = new List<MechCollection>();
-        [SerializeField] private MonzManager monzManager;
 
         public bool CheckAllMechCollection(string newMechName)
         {
-            return _allMechs.All(mech => mech.MechName != newMechName);
+            if (_allMechs == null) return false;
+            return _allMechs.All(mech => mech.mechName != newMechName);
         }
 
         public BigDouble AddMechToCollection(PurchaseInfo info)
@@ -32,7 +32,7 @@ namespace Managers
             for (; index < _allMechs.Count; index++)
             {
                 var mech = _allMechs[index];
-                if (mech.MechName != purchaseInfo.mechName) continue;
+                if (mech.mechName != purchaseInfo.mechName) continue;
                 mech.totalMechs = purchaseInfo.totalAmount;
                 break;
             }
@@ -45,7 +45,7 @@ namespace Managers
             for (; index < _allMechs.Count; index++)
             {
                 var mech = _allMechs[index];
-                if (mech.MechName != upgradeInfo.mechName) continue;
+                if (mech.mechName != upgradeInfo.mechName) continue;
                 mech.totalUpgrades = upgradeInfo.totalAmount;
                 break;
             }
@@ -68,24 +68,131 @@ namespace Managers
         
         public void LoadData(GameData data)
         {
+            if (data == null)
+            {
+                Debug.Log($"got null data in LoadData", gameObject);
+                return;
+            }
             _allMechs = data.allMechsSaved;
+            if (_allMechs == null)
+            {
+                Debug.Log($"had no mechs or upgrades in savedata.  ", gameObject);
+                return;
+            }
+            Debug.Log($"seeing allMechs: total mech slots filled of {_allMechs.Count}");
+            if ( _allMechs == null || _allMechs.Count == 0) return;
+
+            // TODO: Update the slots to reflect the mechs loaded
+            //   and remove all the IDataPersistence logic on those mechslot and mech slot parent 
+
+            // find all objects of type MechSlot
+            // var mechSlotObjects = GameObject.FindObjectsOfType<MechSlot>();
+            var mechSlotParent = GameObject.FindObjectOfType<MechSlotsParent>();
+            
+            // TODO: this is bad practice to directly access, but I want them in the same order as is stored in the Inspector
+            // TODO: perhaps bring mech slot parent list into TotalMechsManager and remove mechslotsparent? 
+            var mechSlotObjects = mechSlotParent.mechSlots;
+            
+            var index = 0;
+
+            if (_allMechs.Count != mechSlotObjects.Count())
+            {
+                Debug.LogWarning($"There are {mechSlotObjects.Count()} mech slots in the scene, but there are {_allMechs.Count} mechs in the save file.", gameObject);
+            }
+
+            if (_allMechs.Count > 0)
+            {
+                // reset monzPerCycleSaved to 0, as we will be adding to it during our load below
+                data.monzPerCycleSaved = 0;
+            }
+            
+            MonzManager.Instance.SetLoadBool(true); // tell MonzManager that we are in load process, to not check or deduct monz
+            foreach (var mechSlotObject in mechSlotObjects)  // FIXME: switch this to loop over the objects from the save slot instead of the ones in the UI
+            {
+                // assuming that we have something in the first index slot, assign it to the first mechSlotObject
+                Debug.Log($"index: {index}  totalMechs: {_allMechs[index].totalMechs} and count: {_allMechs.Count}");
+                if ( _allMechs[index].totalMechs > 0 && _allMechs[index].totalUpgrades > 0 )
+                {
+                    Debug.Log($"Unlocking MechSlotObject of {mechSlotObject.gameObject.name} due to load data at {index}");
+                    //  do logic as CallUnlockSlot() now that he can do it without the monz impact
+                    mechSlotObject.CallUnlockSlot();
+                    mechSlotObject.PassActiveSlotUp();
+                    
+                    // and do the selectMechTypeButton logic for the type at index
+                    var allSelectMechbuttons = GameObject.FindObjectsOfType<SelectMechTypeButton>(true);
+                    var selectedMechTypeButton = allSelectMechbuttons.FirstOrDefault(info =>
+                        info.MechName.Contains(_allMechs[index].mechName, StringComparison.OrdinalIgnoreCase));
+                    Debug.Log($"setting button of {selectedMechTypeButton.gameObject.name} to enabled and doing CallSelectMech at {index}", gameObject);
+                    if (selectedMechTypeButton != null)
+                    {
+                        selectedMechTypeButton.CallSelectMech();
+                        // TODO:  Tell screen manager to enable the right target when I click 
+                    }
+                    else
+                    {
+                        Debug.LogWarning($"Could not find a Upgrade Button for {_allMechs[index].mechName}", gameObject);
+                    }
+                }
+                
+                // find the purchase info for this mech name size
+                var allPurchaseInfos = GameObject.FindObjectsOfType<PurchaseInfo>(includeInactive: true); // note that these are disabled at load time, so I have to find them like this  
+                Debug.Log($"looking for {_allMechs[index].mechName}");
+                var mechPurchaseInfo  = allPurchaseInfos.FirstOrDefault(info =>
+                    info.mechName.Contains(_allMechs[index].mechName, StringComparison.OrdinalIgnoreCase));  // Linq is fun!
+                
+                // and purchase enough of them to match the totalMechs from our save file
+                double _totalMechs = _allMechs[index].totalMechs.ToDouble();
+                for (double i = 0; i < _totalMechs; i++)
+                {
+                    Debug.Log($"{i}: CallPurchaseMech with  {mechPurchaseInfo} and first match mech name was {mechPurchaseInfo.mechName}");
+                    UpgradeManager.Instance.CallPurchaseMech(mechPurchaseInfo);
+                }
+
+                // repeat for the upgrades
+                var allUpgradeInfos = GameObject.FindObjectsOfType<UpgradeInfo>(includeInactive: true);
+                var mechUpgradeInfo  = allUpgradeInfos.FirstOrDefault(info =>
+                    info.mechName.Contains(_allMechs[index].mechName, StringComparison.OrdinalIgnoreCase));
+                double totalUpgrades = _allMechs[index].totalUpgrades.ToDouble();
+                for (double i = 0; i < totalUpgrades; i++)
+                {
+                    Debug.Log($"{i} CalUpgradeMech on {mechUpgradeInfo.mechName}");
+                    UpgradeManager.Instance.CallUpgradeMech(mechUpgradeInfo);
+                }
+                
+                if (index + 1 < _allMechs.Count)
+                {
+                    index++;
+                    Debug.Log($"moving forward to check index: {index} with {_allMechs.Count}");
+                }
+                else
+                {
+                    // no more mechs recorded in save file, we are done here.
+                    Debug.Log($"exiting loop at index: {index} with {_allMechs.Count}");
+                    break;
+                }
+            }
+            
+            MonzManager.Instance.SetLoadBool(false);  // tell MonzManager that we are done loading!
         }
 
         public void SaveData(ref GameData data)
         {
+            if (data == null) return;
+            if (_allMechs == null) return;
+            Debug.Log($"In SaveData of TotalMechsManager: {_allMechs.Count}");
             data.allMechsSaved = _allMechs;
         }
     }
     [Serializable]
     public class MechCollection
     {
-        public readonly string MechName;
+        public string mechName;
         public BigDouble totalMechs;
         public BigDouble totalUpgrades;
 
         public MechCollection(string mechName, BigDouble totalMechs, BigDouble totalUpgrades)
         {
-            MechName = mechName;
+            this.mechName = mechName;
             this.totalMechs = totalMechs;
             this.totalUpgrades = totalUpgrades;
         }

--- a/IdleMechMobile/Assets/Scripts/Managers/TotalMechsManager.cs
+++ b/IdleMechMobile/Assets/Scripts/Managers/TotalMechsManager.cs
@@ -87,6 +87,7 @@ namespace Managers
             if (_allMechs.Count == 0)
             {
                 Debug.Log($"TMM: All mech count was 0");
+                
                 return;
             }
             Debug.Log($"TMM: seeing allMechs: total mech slots filled of {_allMechs.Count}");
@@ -180,6 +181,7 @@ namespace Managers
                     break;
                 }
             }
+            mechSlotParent.ClearSelectedMechSlot(); // clear the selected mech slot for upcoming game state
             MonzManager.Instance.SetLoadBool(false);  // tell MonzManager that we are done loading!
         }
 

--- a/IdleMechMobile/Assets/Scripts/Managers/UpgradeManager.cs
+++ b/IdleMechMobile/Assets/Scripts/Managers/UpgradeManager.cs
@@ -17,9 +17,9 @@ namespace Managers
                 return false;
             }
 
-            var checkForNoMechMatching = TotalMechsManager.Instance.CheckForMechMatching(info.mechName);
+            var checkForMechNameInMechsManager = TotalMechsManager.Instance.CheckForMechMatching(info.mechName);
             BigDouble totalValueOfMechs = 0;
-            if (! checkForNoMechMatching)
+            if (! checkForMechNameInMechsManager)
             {
                 Debug.Log($"UM: didn't have mech {info.mechName}, adding him", gameObject);
                 totalValueOfMechs = TotalMechsManager.Instance.AddMechToCollection(info);

--- a/IdleMechMobile/Assets/Scripts/Managers/UpgradeManager.cs
+++ b/IdleMechMobile/Assets/Scripts/Managers/UpgradeManager.cs
@@ -16,10 +16,21 @@ namespace Managers
                 Debug.Log($"can't purchase mech {info.mechName}");
                 return false;
             }
-            var totalValueOfAllMechs = TotalMechsManager.Instance.CheckAllMechCollection(info.mechName)
-                ? TotalMechsManager.Instance.AddMechToCollection(info)
-                : TotalMechsManager.Instance.UpdateMechInCollection(info);
-            MonzManager.Instance.UpdateCycleValue(totalValueOfAllMechs);
+
+            var checkForNoMechMatching = TotalMechsManager.Instance.CheckForMechMatching(info.mechName);
+            BigDouble totalValueOfMechs = 0;
+            if (! checkForNoMechMatching)
+            {
+                Debug.Log($"UM: didn't have mech {info.mechName}, adding him", gameObject);
+                totalValueOfMechs = TotalMechsManager.Instance.AddMechToCollection(info);
+            }
+            else
+            {
+                Debug.Log($"UM: Already had {info.mechName}, updating him", gameObject);
+                totalValueOfMechs = TotalMechsManager.Instance.UpdateMechInCollection(info);
+            }
+            
+            MonzManager.Instance.UpdateCycleValue(totalValueOfMechs);
             return true;
         }
 
@@ -31,7 +42,7 @@ namespace Managers
         {
             BigDouble totalValueOfAllMechs;
             if (!MonzManager.Instance.UpgradeValue(info)) return false;
-            if (!TotalMechsManager.Instance.CheckAllMechCollection(info.mechName))
+            if (!TotalMechsManager.Instance.CheckForMechMatching(info.mechName))
             {
                 return false;
             }

--- a/IdleMechMobile/Assets/Scripts/Managers/UpgradeManager.cs
+++ b/IdleMechMobile/Assets/Scripts/Managers/UpgradeManager.cs
@@ -1,48 +1,60 @@
 using BreakInfinity;
 using Serialized;
-using Unity.VisualScripting;
 using UnityEngine;
 
 namespace Managers
 {
-    public class UpgradeManager : MonoBehaviour
+    public class UpgradeManager : Singleton<UpgradeManager>
     {
-        [SerializeField] private MonzManager monzManager;
-        [SerializeField] private TimeCycleManager timeCycleManager;
-        [SerializeField] private TotalMechsManager totalMechsManager;
+
         #region MechPurchaseRegion
+
         public bool CallPurchaseMech(PurchaseInfo info)
         {
-            if (!monzManager.UpgradeValue(info)) return false;
-            var totalValueOfAllMechs = totalMechsManager.CheckAllMechCollection(info.mechName) ? totalMechsManager.AddMechToCollection(info) : totalMechsManager.UpdateMechInCollection(info);
-            monzManager.UpdateCycleValue(totalValueOfAllMechs);
+            if (!MonzManager.Instance.UpgradeValue(info))
+            {
+                Debug.Log($"can't purchase mech {info.mechName}");
+                return false;
+            }
+            var totalValueOfAllMechs = TotalMechsManager.Instance.CheckAllMechCollection(info.mechName)
+                ? TotalMechsManager.Instance.AddMechToCollection(info)
+                : TotalMechsManager.Instance.UpdateMechInCollection(info);
+            MonzManager.Instance.UpdateCycleValue(totalValueOfAllMechs);
             return true;
         }
+
         #endregion
+
         #region MechUpgradeRegion
+
         public bool CallUpgradeMech(UpgradeInfo info)
         {
             BigDouble totalValueOfAllMechs;
-            if (!monzManager.UpgradeValue(info)) return false;
-            if (!totalMechsManager.CheckAllMechCollection(info.mechName)) return false;
-            else
+            if (!MonzManager.Instance.UpgradeValue(info)) return false;
+            if (!TotalMechsManager.Instance.CheckAllMechCollection(info.mechName))
             {
-                totalValueOfAllMechs = totalMechsManager.UpdateMechInCollection(info);
+                return false;
             }
-            monzManager.UpdateCycleValue(totalValueOfAllMechs);
-            
-            
+
+            totalValueOfAllMechs = TotalMechsManager.Instance.UpdateMechInCollection(info);
+            MonzManager.Instance.UpdateCycleValue(totalValueOfAllMechs);
+
             return true;
         }
+
         #endregion
+
         #region OverallUpgradeRegion
+
         public void CallUpgradeCycleTimer(PurchaseInfo info)
         {
-            if (monzManager.UpgradeValue(info))
+            if (MonzManager.Instance.UpgradeValue(info))
             {
-                timeCycleManager.DecreaseCycleTimer(info.totalValuePerMech);
+                TimeCycleManager.Instance.DecreaseCycleTimer(info.totalValuePerMech);
             }
         }
+
         #endregion
+
     }
 }

--- a/IdleMechMobile/Assets/Scripts/MechMenuScripts/MechSlot.cs
+++ b/IdleMechMobile/Assets/Scripts/MechMenuScripts/MechSlot.cs
@@ -45,7 +45,7 @@ namespace MechMenuScripts
             // TODO: collect the army counts we have in this slot
             // TotalMechsManager.Instance.GetMech(mechName);
             
-            Debug.Log($"setting up overlay button for {mechName}", gameObject);
+            Debug.Log($"MS: setting up overlay button for {mechName}", gameObject);
             mechSlotsParent.UpdateMechSlotText(buttonText, mechName);
             _mechOverlayOpenButton.SetupListeningOverlayButton(overlayScreen);
             mechSlotsParent.mechSelected = false;

--- a/IdleMechMobile/Assets/Scripts/MechMenuScripts/MechSlot.cs
+++ b/IdleMechMobile/Assets/Scripts/MechMenuScripts/MechSlot.cs
@@ -2,19 +2,21 @@ using ButtonScripts;
 using Managers;
 using TMPro;
 using UnityEngine;
-using UnityEngine.Serialization;
 
 namespace MechMenuScripts
 {
+    [RequireComponent(typeof(LockedMechSlotButton))]
+    [RequireComponent(typeof(MechOverlayOpenButton))]
     public class MechSlot : MonoBehaviour
     {
         [SerializeField] private TextMeshProUGUI buttonText;
         [SerializeField] private MechSlotsParent mechSlotsParent;
+        // [SerializeField] public bool mechSelected;
         //TODO: Save this script, using the script enable to decide what the save hits, be it the required mech overlay 
         //or just the buttonText to state it is still a locked slot
         public LockedMechSlotButton lockedSlotButton;
         private MechOverlayOpenButton _mechOverlayOpenButton;
-    
+        
         private void OnEnable()
         {
             if (!lockedSlotButton) lockedSlotButton = GetComponent<LockedMechSlotButton>();
@@ -39,6 +41,11 @@ namespace MechMenuScripts
         public void SetupOverlayButton()
         {
             var mechName = mechSlotsParent.MechSlotRequestInfo(out var overlayScreen);
+            
+            // TODO: collect the army counts we have in this slot
+            // TotalMechsManager.Instance.GetMech(mechName);
+            
+            Debug.Log($"setting up overlay button for {mechName}", gameObject);
             mechSlotsParent.UpdateMechSlotText(buttonText, mechName);
             _mechOverlayOpenButton.SetupListeningOverlayButton(overlayScreen);
             mechSlotsParent.mechSelected = false;
@@ -55,7 +62,7 @@ namespace MechMenuScripts
         }
         public bool CheckMechSelected()
         {
-            return mechSlotsParent.mechSelected;
+            return mechSlotsParent.mechSelected; // return if this particular slot has a value in it
         }
 
 

--- a/IdleMechMobile/Assets/Scripts/MechMenuScripts/MechSlotSaveObject.cs
+++ b/IdleMechMobile/Assets/Scripts/MechMenuScripts/MechSlotSaveObject.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace MechMenuScripts
 {
-    public class MechSlotSaveObject : MonoBehaviour
+    public class MechSlotSaveObject : MonoBehaviour, IDataPersistence
     {
         public MechSlot mechSlot;
         public bool isUnlocked;
@@ -16,7 +16,7 @@ namespace MechMenuScripts
 
         public void RebuildButton()
         {
-            
+            Debug.LogWarning($"TODO: make RebuildButton build from save data in {mechSlot.gameObject.name}", gameObject);
         }
 
         private void OnEnable()
@@ -30,52 +30,19 @@ namespace MechMenuScripts
             }
         }
 
-        /*//From mechslot, we need the buttonText, and which of the two buttons are active
-
-        private string _buttonText;
-        private bool _isLocked;
-        
-        
-        //From lockedslot, we need the price to unlock
-        private LockedMechSlotButton _lockedSlot;
-        private BigDouble _priceToUnlock;
-        
-        
-        
-        //From overlayslot, we need the overlayscreen and whether it has had a mech selected or not
-        private MechOverlayOpenButton _overlaySlot;
-        private GameObject _overlayScreen;
-        private bool _mechSelected;
-        
-        
-        private void OnEnable()
+        public void LoadData(GameData data)
         {
-            if (!_mechSlot)
-            {
-                _mechSlot = GetComponent<MechSlot>();
-                _buttonText = _mechSlot.GetTextObject();
-                _isLocked = _mechSlot.lockedSlotButton;
-            }
-
-            if (!_lockedSlot)
-            {
-                _lockedSlot = GetComponent<LockedMechSlotButton>();
-                _priceToUnlock = _lockedSlot.GetPriceToUnlock();
-            }
-
-            if (!_overlaySlot)
-            {
-                _overlaySlot = GetComponent<MechOverlayOpenButton>();
-                _overlayScreen = _overlaySlot.GetOverlayScreen();
-                _mechSelected = _overlaySlot.IsMechSelected();
-            }
+            // Debug.LogWarning($"Implement LoadData for {mechSlot.gameObject.name}", gameObject);
+            // _monzBigDoubleHolder = data.totalMonzSaved;
+            // _monzPerCycle = data.monzPerCycleSaved;
+            // UpdateStartMoneyText();
         }
 
-        public void RebuildButton()
+        public void SaveData(ref GameData data)
         {
-            _mechSlot.UpdateButtonText(_buttonText);
-            _mechSlot.UpdateIsLocked(_isLocked);
-        }*/
-
+            // Debug.LogWarning($"Implement SaveData for {mechSlot.gameObject.name}", gameObject);
+            // data.mechSlot = _monzBigDoubleHolder;
+            // data.monzPerCycleSaved = _monzPerCycle;
+        }
     }
 }

--- a/IdleMechMobile/Assets/Scripts/MechMenuScripts/MechSlotsParent.cs
+++ b/IdleMechMobile/Assets/Scripts/MechMenuScripts/MechSlotsParent.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using BreakInfinity;
 using DataPersistence;
@@ -8,19 +7,25 @@ using UnityEngine;
 
 namespace MechMenuScripts
 {
-    public class MechSlotsParent : MonoBehaviour, IDataPersistence
+    public class MechSlotsParent : MonoBehaviour
     {
         
-        //TODO: Need to get someway to link the mechSlots to their selected mech, probably through the totalmechsmanager or something so it can be saved in the save system
-        [SerializeField] private List<MechSlotSaveObject> mechSlots;
+        //TODO: Need to get someway to link the mechSlots to their selected mech, probably through the TotalMechManager or something so it can be saved in the save system
+        [SerializeField] public List<MechSlot> mechSlots;
+        private MechSlot _activelyUpdatingMechSlot;
+        private string _tempNameHolder;
+        private GameObject _overlayScreenHolder;
+        public bool mechSelected;  //FIXME: I think this should be per MechSlot, not at the parent level
         
-        [SerializeField] private MonzManager monzManager;
+        private void Awake()
+        {
+            // TODO: subscribe to data change events in TotalMechsManager
+        }
 
-        [SerializeField] private MechSelectionScreenManager mechSelectionScreenManager;
-
+        
         public bool UnlockSlot(BigDouble priceToUnlock)
         {
-            return monzManager.TrySpend(priceToUnlock);
+            return MonzManager.Instance.TrySpend(priceToUnlock);
         }
 
         public void UpdateMechSlotText(TextMeshProUGUI textToUpdate, string newText)
@@ -28,21 +33,17 @@ namespace MechMenuScripts
             TextManager.UpdateAnyBasicText(textToUpdate, newText);
         }
 
-        private MechSlot _activelyUpdatingMechSlot;
-        private string _tempNameHolder;
-        private GameObject _overlayScreenHolder;
-        public bool mechSelected;
         public void AffectMechSlot(string mechName, GameObject overlayScreen)
         {
             _tempNameHolder = mechName;
             _overlayScreenHolder = overlayScreen;
-            mechSelected = true;
+            mechSelected = true;  //FIXME:  How do I know which child mech slot has been impacted?  
         }
 
         public string MechSlotRequestInfo(out GameObject overlayScreen)
         {
             overlayScreen = _overlayScreenHolder;
-            return _tempNameHolder;
+            return _tempNameHolder; 
         }
         
         public void SetActiveMechSlot(MechSlot newMechSlot)
@@ -55,34 +56,35 @@ namespace MechMenuScripts
             return _activelyUpdatingMechSlot;
         }
 
-        public void LoadData(GameData data)
-        {
-            mechSlots = data.mechSlotsSaved;
-            if (mechSlots == null || mechSlots.Count == 0 || (mechSlots[0] == null && mechSlots[1] == null && mechSlots[2] == null))
-            {
-                Debug.Log("Refilling emptied mechslotparent list:");
-                var foundMechSlots = FindObjectsOfType<MechSlotSaveObject>();
-                mechSlots = new List<MechSlotSaveObject>();
-                foreach (var e in foundMechSlots)
-                {
-                    mechSlots.Add(e);
-                    mechSlots.Reverse();
-                }
-            }
-            else
-            {
-                //TODO: Rebuild the buttons to be the way they need to be based on the info in the mechslotsaveobject
-                foreach (var slot in mechSlots)
-                {
-                    slot.RebuildButton();
-                }
-            }
-
-        }
-
-        public void SaveData(ref GameData data)
-        {
-            data.mechSlotsSaved = mechSlots;
-        }
+        // public void LoadData(GameData data)
+        // {
+        //     Debug.Log($"Doing LoadData for {gameObject.name}", gameObject);
+        //     mechSlots = data.mechSlotsSaved;
+        //     if (mechSlots == null || mechSlots.Count == 0 || (mechSlots[0] == null && mechSlots[1] == null && mechSlots[2] == null))
+        //     {
+        //         Debug.Log("Refilling emptied MechSlowParent list:", gameObject);
+        //         var foundMechSlots = FindObjectsOfType<MechSlotSaveObject>();
+        //         mechSlots = new List<MechSlotSaveObject>();
+        //         foreach (var e in foundMechSlots)
+        //         {
+        //             mechSlots.Add(e);
+        //             mechSlots.Reverse();
+        //         }
+        //     }
+        //     else
+        //     {
+        //         //TODO: Rebuild the buttons to be the way they need to be based on the info in the MechSlotSaveObjects
+        //         foreach (var slot in mechSlots)
+        //         {
+        //             slot.RebuildButton();
+        //         }
+        //     }
+        //
+        // }
+        //
+        // public void SaveData(ref GameData data)
+        // {
+        //     data.mechSlotsSaved = mechSlots;
+        // }
     }
 }

--- a/IdleMechMobile/Assets/Scripts/MechMenuScripts/MechSlotsParent.cs
+++ b/IdleMechMobile/Assets/Scripts/MechMenuScripts/MechSlotsParent.cs
@@ -22,7 +22,14 @@ namespace MechMenuScripts
             // TODO: subscribe to data change events in TotalMechsManager
         }
 
-        
+        public void ClearSelectedMechSlot()
+        {
+            Debug.Log($"MSP: Clearing selected mech slot data", gameObject);
+            _activelyUpdatingMechSlot = null;
+            _tempNameHolder = null;
+            _overlayScreenHolder = null;
+            mechSelected = false;
+        }
         public bool UnlockSlot(BigDouble priceToUnlock)
         {
             return MonzManager.Instance.TrySpend(priceToUnlock);
@@ -37,7 +44,7 @@ namespace MechMenuScripts
         {
             _tempNameHolder = mechName;
             _overlayScreenHolder = overlayScreen;
-            mechSelected = true;  //FIXME:  How do I know which child mech slot has been impacted?  
+            mechSelected = true;
         }
 
         public string MechSlotRequestInfo(out GameObject overlayScreen)

--- a/IdleMechMobile/Assets/Scripts/Serialized/PurchaseInfo.cs
+++ b/IdleMechMobile/Assets/Scripts/Serialized/PurchaseInfo.cs
@@ -28,5 +28,14 @@ namespace Serialized
         public int totalValuePerMech = 1;
         //If I put this in in the future, its the cost enhancement that happens from buying other mech types before this one. For now, ignoring to get project working 1/12/2024
         public int initialMultiplierCost = 1;
+
+        private void OnEnable()
+        {
+            // find my text if there is one and tell him the cost for this Purchase
+            if (costTextConnection!= null)
+            {
+                costTextConnection.text = $"Spend {purchaseCost.ToDouble()} Monz\nTo Upgrade";
+            }
+        }
     }
 }


### PR DESCRIPTION
Things to note to test this PR: 

1) wipe out your data.game file.  This version has slightly different data in it. 
2) time cycle manager has his cycle duration set to 1 to facilitate easier /faster testing with empty data
3) There is a TON of debug data logs that I still have spitting to console.  After this method of data persistence has been approved, I'll do another run where I remove the debug log statements.  
4) all managers have been converted to Singletons to simplify the interconnectivity for now.  
5) I have lowered the cost of slots and mechs in many of the PurchaseInfo locations.  This stuff should be scriptable objects anyways, so I'll do a future PR where we can balance them.  
6) I tried to add RequireComponent in for everywhere that we absolutely do depend on those components being setup to avoid future bugs.  
7) In all the locations where we were trying to take a BigDouble ToString(), I replaced it with a ToDouble() and let the string interpretation do the ToString() for me.  This fixed the 20e2 strings from appearing all around the app. 
8) I had to comment out all of IdleMechMobile/Assets/Scripts/EditorExtensions/MaterialApplication.cs because the rest of his package wasn't available, and I didn't expect to change the materials on the mechs. 

Most importantly, the only to managers who are saving or loading data at this point are TotalMechsManager and MonzManager.  Note that I've commented out all the logic in MechSlotSaveObject, and we can likely remove it's IDataPersistence interface 
